### PR TITLE
Don't enforce that branches are up to date before merging

### DIFF
--- a/github/main.tf
+++ b/github/main.tf
@@ -69,7 +69,7 @@ resource github_branch_protection infra-main {
   enforce_admins = true
   require_conversation_resolution = true
   required_status_checks {
-    strict = true
+    strict = false # don't need the branch to be up-to-date
     contexts = [ "all-good" ]
   }
 


### PR DESCRIPTION
This removes the need to constantly merge main into PR branches.