### PR TITLE
Enable waiting for terraform state lock

### DIFF
--- a/common/provisioner_utils.py
+++ b/common/provisioner_utils.py
@@ -93,13 +93,13 @@ def run_terraform_generic_with_var_files(env: ProvisionerEnvironment, command: s
     return run_terraform_generic(env, command, var_flags + additional_args)
 
 def run_terraform_init(env: ProvisionerEnvironment, additional_args=[]):
-    return run_terraform_generic(env, "init", additional_args)
+    return run_terraform_generic(env, "init", [ "-lock-timeout=20m" ] + additional_args)
 
 def run_terraform_plan(env: ProvisionerEnvironment, additional_args=[]):
-    return run_terraform_generic_with_var_files(env, "plan", additional_args)
+    return run_terraform_generic_with_var_files(env, "plan", [ "-lock-timeout=20m", "-refresh=false" ] + additional_args)
 
 def run_terraform_apply(env: ProvisionerEnvironment, additional_args=[]):
-    return run_terraform_generic_with_var_files(env, "apply", additional_args)
+    return run_terraform_generic_with_var_files(env, "apply", [ "-lock-timeout=20m" ] + additional_args)
 
 def get_terraform_output(env: ProvisionerEnvironment, additional_args=[]):
     res = run_terraform_generic(env, "output", ["-json"] + additional_args, subprocess_args={'capture_output': True, 'text': True})

--- a/kubernetes/terragrunt.hcl
+++ b/kubernetes/terragrunt.hcl
@@ -11,6 +11,22 @@ terraform {
       "${get_env("PROV_RUN_DIR")}/terraform.tfvars.json",
     ]
   }
+
+  extra_arguments "retry_lock" {
+    commands = [
+      "init",
+      "apply",
+      "refresh",
+      "import",
+      "plan",
+      "taint",
+      "untaint"
+    ]
+
+    arguments = [
+      "-lock-timeout=20m"
+    ]
+  }
 }
 
 generate backend {


### PR DESCRIPTION
By default, terraform doesn't wait for state lock. 

This PR adds a timeout for waiting for locks. 


References:
- https://developer.hashicorp.com/terraform/cli/commands/init#lock-timeout
- https://terragrunt.gruntwork.io/docs/features/keep-your-cli-flags-dry/#motivation