### PR TITLE
Increase elastic storage to 8Gi

### DIFF
--- a/kubernetes/elastic/eck-stack.tf
+++ b/kubernetes/elastic/eck-stack.tf
@@ -131,7 +131,7 @@ resource "kubectl_manifest" "elasticsearch-es1" {
                 "accessModes" = ["ReadWriteOnce"]
                 "resources" = {
                   "requests" = {
-                    "storage" = "4Gi"
+                    "storage" = "8Gi"
                   }
                 }
               }


### PR DESCRIPTION
Elastic ran out of storage and Kibana started throwing 429 too many requests (https://stackoverflow.com/questions/65368970/kibana-throwing-429-too-many-requests-when-trying-to-create-an-index-pattern). This adds more.