### PR TITLE
Expand elastic storage to 16 GiB

### DIFF
--- a/kubernetes/elastic/eck-stack.tf
+++ b/kubernetes/elastic/eck-stack.tf
@@ -131,7 +131,7 @@ resource "kubectl_manifest" "elasticsearch-es1" {
                 "accessModes" = ["ReadWriteOnce"]
                 "resources" = {
                   "requests" = {
-                    "storage" = "8Gi"
+                    "storage" = "16Gi"
                   }
                 }
               }


### PR DESCRIPTION
Elastic is filling up fast, it's now at 7.2GiB/8GiB: 
<img width="1552" alt="image" src="https://github.com/unicorns/infra/assets/5977478/8733c8a1-9357-4daa-8b5a-4327f5396e68">

We expanded the storage from 4G to 8G in #25. At this rate, we are consuming about 1GiB/day. Hopefully index cleanup gets kicks in for some monitoring indices (they are supposed to be cleaned up after 7 days IIRC):

<img width="2672" alt="image" src="https://github.com/unicorns/infra/assets/5977478/a542a6d2-d25e-4222-b149-5b0e7d52aba5">
