### PR TITLE
Increase Elastic storage from 16Gi to 32Gi

### DIFF
--- a/kubernetes/elastic/eck-stack.tf
+++ b/kubernetes/elastic/eck-stack.tf
@@ -131,7 +131,7 @@ resource "kubectl_manifest" "elasticsearch-es1" {
                 "accessModes" = ["ReadWriteOnce"]
                 "resources" = {
                   "requests" = {
-                    "storage" = "16Gi"
+                    "storage" = "32Gi"
                   }
                 }
               }


### PR DESCRIPTION
10.2Gi is used right now:
<img width="2672" alt="image" src="https://github.com/unicorns/infra/assets/5977478/0f180e28-2d22-4b7b-b9fc-11f99c30fbab">

Still about 1Gi/day since the last expansion: https://github.com/unicorns/infra/pull/26