### PR TITLE
Disable nginx ingress default backend

### DIFF
--- a/kubernetes/system/ingress.tf
+++ b/kubernetes/system/ingress.tf
@@ -20,12 +20,6 @@ resource "helm_release" "ingress_nginx" {
           service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
       metrics:
         enabled: true
-    defaultBackend:
-      enabled: true
-      image:
-        registry: registry.k8s.io
-        image: ingress-nginx/nginx-errors
-        tag: "v20230404-helm-chart-4.6.0-11-gc76179c04@sha256:aabd7a001f6a0a07ed6ea8f6da87e928bfa8f971eba2bef708f3e8504fc5cc9b"
   EOF
   ]
 }


### PR DESCRIPTION
Disable defaultbackend because the image we are using doesn't support running on ARM:
<img width="1232" alt="image" src="https://github.com/unicorns/infra/assets/5977478/36943d1a-ae04-4945-9726-0936f0c23b4d">

We used to use it for custom error pages, but not anymore.

Background: we switched the default node pool to ARM in https://github.com/unicorns/infra/pull/39