### PR TITLE
Allow creating child tokens in rw policies

### DIFF
--- a/vault/main.tf
+++ b/vault/main.tf
@@ -109,6 +109,13 @@ resource "vault_policy" "provisioner-rw" {
     path "secret/data/states/*" {
       capabilities = ["create", "read", "update"]
     }
+
+    # Allow creating child tokens. Otherwise we'll need to enable skip_child_token when using this policy with
+    # vault providers.
+    # https://support.hashicorp.com/hc/en-us/articles/360034820694-Parent-Child-Token-Hierarchy
+    path "auth/token/create" {
+      capabilities = ["create", "update"]
+    }
     EOF
 }
 
@@ -147,6 +154,13 @@ resource "vault_policy" "base-user" {
       allowed_parameters = {
         "password" = []
       }
+    }
+
+    # Allow creating child tokens. Otherwise we'll need to enable skip_child_token when using this policy with
+    # vault providers.
+    # https://support.hashicorp.com/hc/en-us/articles/360034820694-Parent-Child-Token-Hierarchy
+    path "auth/token/create" {
+      capabilities = ["create", "update"]
     }
     EOF
 }


### PR DESCRIPTION
The vault provider [creates child tokens](https://github.com/hashicorp/terraform-provider-vault/blob/6c21252ea1b5d187b500039b81b8447c9508bb10/website/docs/index.html.markdown?plain=1#L176-L186) by default for security. In #41 we added a provider that runs in CI using the provisioner-rw policy. This PR gives permissions to that policy to create child tokens.

Also added the same permission to the base-user policy, in case we need to use this in the future.

Without this change, we get 403:
https://github.com/unicorns/infra/actions/runs/9651892467/job/26620960661
<img width="1552" alt="image" src="https://github.com/unicorns/infra/assets/5977478/58b85d3e-c86c-4b55-95ad-75757377526a">
