### PR TITLE
Reduce elastic memory limit to 6Gi

### DIFF
--- a/kubernetes/elastic/eck-stack.tf
+++ b/kubernetes/elastic/eck-stack.tf
@@ -110,7 +110,7 @@ resource "kubectl_manifest" "elasticsearch-es1" {
                   # https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-managing-compute-resources.html#k8s-compute-resources
                   "resources" = {
                     "limits" = {
-                      "memory" = "8Gi"
+                      "memory" = "6Gi"
                     }
                     "requests" = {
                       "memory" = "4Gi"


### PR DESCRIPTION
The node pools are unable to scale up because the 16GB pool went above price threshold and the pod doesn't want to schedule on the 8GB pool due to insufficient memory:

<img width="1635" alt="image" src="https://github.com/unicorns/infra/assets/5977478/5ab577a8-554c-4299-8043-9e3f663e72a9">

[source](https://portal.azure.com/#view/Microsoft_Azure_ContainerService/AksEvents.Reactview/aksClusterId/%2Fsubscriptions%2Fda091416-7245-487a-a165-deb1cb35397e%2FresourceGroups%2Funicorns-aks1-rg%2Fproviders%2FMicrosoft.ContainerService%2FmanagedClusters%2Funicorns-aks1/eventScope/cluster/defaultFilters~/%7B%22eventSource%22%3A%22cluster-autoscaler%22%2C%22eventType%22%3A%22Normal%22%2C%22eventReason%22%3A%22NotTriggerScaleUp%22%7D)