### PR TITLE
Reduce elastic memory limit to 4Gi

### DIFF
--- a/kubernetes/elastic/eck-stack.tf
+++ b/kubernetes/elastic/eck-stack.tf
@@ -110,7 +110,7 @@ resource "kubectl_manifest" "elasticsearch-es1" {
                   # https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-managing-compute-resources.html#k8s-compute-resources
                   "resources" = {
                     "limits" = {
-                      "memory" = "6Gi"
+                      "memory" = "4Gi"
                     }
                     "requests" = {
                       "memory" = "4Gi"


### PR DESCRIPTION
Apparently [reducing it to 6Gi](https://github.com/unicorns/infra/pull/45) wasn't enough:

```yaml
kind: Event
apiVersion: v1
metadata:
  name: es1-es-default-0.17dddc1a8b2d204e
  namespace: elastic-stack
  uid: 626db6a4-ed5d-465b-8220-e1c9ba8b9d29
  resourceVersion: '22986600'
  creationTimestamp: '2024-06-30T18:37:19Z'
  managedFields:
    - manager: cluster-autoscaler
      operation: Update
      apiVersion: v1
      time: '2024-06-30T18:42:26Z'
      fieldsType: FieldsV1
      fieldsV1:
        f:count: {}
        f:firstTimestamp: {}
        f:involvedObject: {}
        f:lastTimestamp: {}
        f:message: {}
        f:reason: {}
        f:reportingComponent: {}
        f:source:
          f:component: {}
        f:type: {}
involvedObject:
  kind: Pod
  namespace: elastic-stack
  name: es1-es-default-0
  uid: 4a277800-0b71-45a4-a653-717fa16718e7
  apiVersion: v1
  resourceVersion: '22985063'
reason: NotTriggerScaleUp
message: >-
  pod didn't trigger scale-up: 1 Insufficient memory, 1 in backoff after failed
  scale-up
source:
  component: cluster-autoscaler
firstTimestamp: '2024-06-30T18:37:19Z'
lastTimestamp: '2024-06-30T18:42:26Z'
count: 28
type: Normal
eventTime: null
reportingComponent: cluster-autoscaler
reportingInstance: ''
```