### PR TITLE
Reduce elastic memory request to 2Gi

### DIFF
--- a/kubernetes/elastic/eck-stack.tf
+++ b/kubernetes/elastic/eck-stack.tf
@@ -113,7 +113,7 @@ resource "kubectl_manifest" "elasticsearch-es1" {
                       "memory" = "4Gi"
                     }
                     "requests" = {
-                      "memory" = "4Gi"
+                      "memory" = "2Gi"
                     }
                   }
                 }


### PR DESCRIPTION
#46 was still unable to scale up due to insufficient memory, which is very strange because our poll has 8GB memory, of which at least 5Gi is allocatable. Perhaps the calculations already takes into account system pods? This tells us that perhaps memory requests is the one preventing scale-up, not memory limits.

This PR reduces the memory request to 2Gi. It turns out that this makes the pod fit on the default nodes, so there's no need to scale up.