### PR TITLE
Deploy kube-state-metrics

### DIFF
--- a/elastic/main.tf
+++ b/elastic/main.tf
@@ -27,6 +27,11 @@ provider "elasticstack" {
     password  = var.elastic_password
     endpoints = ["https://elasticsearch.benzhang.dev"]
   }
+  kibana {
+    username  = "elastic"
+    password  = var.elastic_password
+    endpoints = ["https://kibana.benzhang.dev"]
+  }
 }
 
 data "elasticstack_elasticsearch_info" "cluster_info" {
@@ -37,18 +42,18 @@ resource "elasticstack_elasticsearch_index_lifecycle" "logs" {
 
   metadata = jsonencode({
     description = "[Managed by Terraform] (Modified) default policy for the logs index template installed by x-pack"
-    managed = true
+    managed     = true
   })
 
   hot {
     min_age = "0ms"
 
     rollover {
-      max_age = "30d"
+      max_age                = "30d"
       max_primary_shard_size = "10gb"
     }
   }
-  
+
   delete {
     min_age = "5d"
     delete {}
@@ -57,4 +62,118 @@ resource "elasticstack_elasticsearch_index_lifecycle" "logs" {
 import {
   to = elasticstack_elasticsearch_index_lifecycle.logs
   id = "${data.elasticstack_elasticsearch_info.cluster_info.cluster_uuid}/logs"
+}
+
+resource "elasticstack_fleet_integration" "kubernetes" {
+  name    = "kubernetes"
+  version = "1.58.0"
+}
+
+resource "elasticstack_fleet_agent_policy" "eck-agent" {
+  name      = "Elastic Agent on ECK policy (managed by Terraform)"
+  namespace = "default"
+
+  monitor_logs    = true
+  monitor_metrics = true
+}
+import {
+  to = elasticstack_fleet_agent_policy.eck-agent
+  # This is a preconfigured policy from the ECK stack
+  id = "eck-agent"
+}
+
+locals {
+  # Deployed using the Kubernetes provisioner
+  kube_state_metrics_stream_vars = {
+    hosts = ["kube-state-metrics.kube-state-metrics.svc.cluster.local:8080"],
+
+    # Default settings to prevent perpetual diffs
+    add_metadata                  = true
+    bearer_token_file             = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    leaderelection                = true
+    period                        = "10s"
+    "ssl.certificate_authorities" = []
+  }
+}
+
+resource "elasticstack_fleet_integration_policy" "eck-agent-kubernetes" {
+  name                = "Kubernetes Integration (managed by Terraform)"
+  namespace           = "default"
+  agent_policy_id     = elasticstack_fleet_agent_policy.eck-agent.id
+  integration_name    = elasticstack_fleet_integration.kubernetes.name
+  integration_version = elasticstack_fleet_integration.kubernetes.version
+
+  input {
+    input_id = "kubelet-kubernetes/metrics"
+  }
+  input {
+    input_id = "kube-state-metrics-kubernetes/metrics"
+    streams_json = jsonencode(merge(
+      {
+        for name in [
+          "kubernetes.state_cronjob",
+          "kubernetes.state_daemonset",
+          "kubernetes.state_deployment",
+          "kubernetes.state_job",
+          "kubernetes.state_namespace",
+          "kubernetes.state_node",
+          "kubernetes.state_persistentvolume",
+          "kubernetes.state_persistentvolumeclaim",
+          "kubernetes.state_replicaset",
+          "kubernetes.state_resourcequota",
+          "kubernetes.state_service",
+          "kubernetes.state_statefulset",
+          "kubernetes.state_storageclass",
+        ] :
+        name => {
+          enabled = true
+          vars    = local.kube_state_metrics_stream_vars
+        }
+      },
+      {
+        # These streams have extra variables
+        for name in [
+          "kubernetes.state_container",
+          "kubernetes.state_pod",
+        ] :
+        name => {
+          enabled = true
+          vars = merge(local.kube_state_metrics_stream_vars, {
+            add_resource_metadata_config = ""
+          })
+        }
+      }
+    ))
+  }
+  input {
+    input_id = "kube-apiserver-kubernetes/metrics"
+  }
+  input {
+    input_id = "kube-proxy-kubernetes/metrics"
+  }
+  input {
+    input_id = "kube-scheduler-kubernetes/metrics"
+    enabled  = false
+  }
+  input {
+    input_id = "kube-controller-manager-kubernetes/metrics"
+    enabled  = false
+  }
+  input {
+    input_id = "events-kubernetes/metrics"
+  }
+  input {
+    input_id = "container-logs-filestream"
+  }
+  input {
+    input_id = "audit-logs-filestream"
+    enabled  = false
+  }
+}
+import {
+  to = elasticstack_fleet_integration_policy.eck-agent-kubernetes
+  # Manually obtained from https://kibana.benzhang.dev/app/fleet/policies/eck-agent/edit-integration/a3b718bd-efec-54f4-b513-7711c744a8ec
+  # In the future, we should configure an empty package policy list in the eck-stack provisioner and
+  # define the package policy here instead.
+  id = "a3b718bd-efec-54f4-b513-7711c744a8ec"
 }

--- a/kubernetes/elastic/eck-stack.tf
+++ b/kubernetes/elastic/eck-stack.tf
@@ -197,6 +197,15 @@ resource "kubectl_manifest" "elasticsearch-es1-ingress" {
 }
 
 locals {
+  # Packge policy schema:
+  # https://github.com/elastic/kibana/blob/d887763f0ee08257db8a6838cdab94f075b95619/x-pack/plugins/fleet/server/types/models/preconfiguration.ts#L144
+  # Note that preconfigured policies cannot be changed here after they are created:
+  # https://discuss.elastic.co/t/how-to-update-preconfigured-fleet-agent-policies/337801
+  # https://github.com/elastic/kibana/issues/111401
+  # To change these policies, use the API/elasticstack Terraform provider:
+  # https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/resources/fleet_agent_policy
+  # https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/resources/fleet_integration_policy
+
   # Derived from https://github.com/elastic/cloud-on-k8s/blob/9dd6dfce933f811cfc307b14c0d2c60cb45c5fe0/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml#L23-L34
   eck_fleet_server_policy = yamldecode(
     <<-EOF

--- a/kubernetes/kube-state-metrics/.terraform.lock.hcl
+++ b/kubernetes/kube-state-metrics/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+../_common/.terraform.lock.hcl

--- a/kubernetes/kube-state-metrics/terragrunt.hcl
+++ b/kubernetes/kube-state-metrics/terragrunt.hcl
@@ -1,0 +1,1 @@
+../_common/terragrunt.common.hcl

--- a/kubernetes/kube-state-metrics/vault.tf
+++ b/kubernetes/kube-state-metrics/vault.tf
@@ -1,0 +1,30 @@
+resource "kubernetes_namespace" "kube-state-metrics" {
+  metadata {
+    name = "kube-state-metrics"
+  }
+}
+
+resource "helm_release" "kube-state-metrics" {
+  name       = "kube-state-metrics"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "kube-state-metrics"
+  namespace  = kubernetes_namespace.kube-state-metrics.metadata.0.name
+
+  set {
+    name = "resources.requests.cpu"
+    value = "10m"
+  }
+  set {
+    name = "resources.requests.memory"
+    value = "32Mi"
+  }
+
+  set {
+    name = "resources.limits.cpu"
+    value = "100m"
+  }
+  set {
+    name = "resources.limits.memory"
+    value = "250Mi"
+  }
+}


### PR DESCRIPTION
This PR deploys [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics?tab=readme-ov-file#kube-state-metrics-vs-metrics-server) and configures the Elastic Agents to scrape from it.

Previously, there are a lot of errors related to elastic agent not able to access kube-state-metrics. Now the errors are gone:

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/880c7048-9225-40c4-84ab-ae0b55377abf">
