### PR TITLE
Upgrade AKS to 1.30.3 and decrease system pool node count to 1

### DIFF
--- a/azure/main.tf
+++ b/azure/main.tf
@@ -46,7 +46,7 @@ resource "azurerm_resource_group" "unicorns-aks1" {
 }
 
 locals {
-  kubernetes_version = "1.29.5"
+  kubernetes_version = "1.30.3"
 }
 
 resource "azurerm_kubernetes_cluster" "unicorns-aks1" {
@@ -59,7 +59,7 @@ resource "azurerm_kubernetes_cluster" "unicorns-aks1" {
 
   default_node_pool {
     name       = "default"
-    node_count = 2
+    node_count = 1
 
     orchestrator_version = local.kubernetes_version
 
@@ -121,6 +121,16 @@ resource "azurerm_kubernetes_cluster" "unicorns-aks1" {
     skip_nodes_with_system_pods = false
     # Support deleting nodes with local storage (emptyDir or localPath volumes)
     skip_nodes_with_local_storage = false
+  }
+
+  node_os_channel_upgrade = "NodeImage"
+  maintenance_window_node_os {
+    frequency = "Weekly"
+    interval = 1
+    duration = 4 # hours
+    day_of_week = "Sunday"
+
+    start_time = "09:00" # UTC. This is 2 AM PDT or 1 AM PST.
   }
 }
 

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -69,7 +69,7 @@ resource "azurerm_kubernetes_cluster" "unicorns-aks1" {
 
     # 2 vCPU, 4 GiB RAM. 8 GiB temp disk. 30 GiB cache. $378.43/year.
     # vm_size    = "Standard_B2s"
-    # 2 vCPU, 4 GiB RAM. No temp disk. Does not support ephemeral OS disk. $602.69/year.
+    # 2 vCPU, 8 GiB RAM. No temp disk. Does not support ephemeral OS disk. $602.69/year.
     vm_size    = "Standard_B2ps_v2"
     # 2 vCPU, 8 GiB RAM. 16 GiB temp disk. 30 GiB cache. $756.86/year.
     # vm_size    = "Standard_B2ms"


### PR DESCRIPTION
It turns out we don't need to have at least 2 nodes in the system pool. And all of our workloads fit on a single node.

Also add a maintenance window for Sunday mornings.