### PR TITLE
Always use amd64 for provisioner image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
       context: .
       cache_from:
         - type=registry,ref=ghcr.io/unicorns/infra:buildcache
+      platforms:
+        - linux/amd64
     volumes:
       - .:/${COMPOSE_PROJECT_NAME:?}:ro
       # The output directory is mounted as rw so that the provisioner can write


### PR DESCRIPTION
Our Dockerfile hard-codes some amd64-specific binary downloads. This PR makes it so that we don't attempt to build for any other architecture.

Same change as https://github.com/WATonomous/infra-config/pull/3393
