### PR TITLE
Allow dashes in provisioner names

### DIFF
--- a/.github/workflows/provision.generated.yml
+++ b/.github/workflows/provision.generated.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Revoke Vault token
         if: always()
         run: 'curl -X POST -sv -H "X-Vault-Token: ${{ env.VAULT_TOKEN }}" ${{ vars.VAULT_ADDR }}/v1/auth/token/revoke-self'
-  provision-kubernetesaks2:
+  provision-kubernetes-aks2:
     needs:
       - update-workflow
     runs-on: ubuntu-latest
@@ -271,7 +271,7 @@ jobs:
       - provision-elastic
       - provision-github
       - provision-kubernetes
-      - provision-kubernetesaks2
+      - provision-kubernetes-aks2
       - provision-users
       - update-workflow
     runs-on: ubuntu-latest

--- a/common/utils.libsonnet
+++ b/common/utils.libsonnet
@@ -6,10 +6,11 @@
     // Convert string to array of characters
     local chars = std.stringChars(lowercase);
 
-    // Define allowed characters (alphanumeric and space)
+    // Define allowed characters (alphanumeric, dash, and space)
     local isAllowed = function(c) (
       (c >= '0' && c <= '9') ||
       (c >= 'a' && c <= 'z') ||
+      c == '-' ||
       c == ' '
     );
 


### PR DESCRIPTION
This properly slugifies `Provision kubernetes-aks2` to `provision-kubernetes-aks2` instead of the current `provision-kubernetesaks2`.