### PR TITLE
Deploy hashicorp vault on AKS2

### DIFF
--- a/.github/workflows/provision.generated.yml
+++ b/.github/workflows/provision.generated.yml
@@ -64,7 +64,7 @@ jobs:
       id-token: write
     steps:
       - name: Set up Vault
-        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b
         with:
           exportToken: true
           method: jwt
@@ -99,7 +99,7 @@ jobs:
       id-token: write
     steps:
       - name: Set up Vault
-        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b
         with:
           exportToken: true
           method: jwt
@@ -134,7 +134,7 @@ jobs:
       id-token: write
     steps:
       - name: Set up Vault
-        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b
         with:
           exportToken: true
           method: jwt
@@ -169,7 +169,7 @@ jobs:
       id-token: write
     steps:
       - name: Set up Vault
-        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b
         with:
           exportToken: true
           method: jwt
@@ -204,7 +204,7 @@ jobs:
       id-token: write
     steps:
       - name: Set up Vault
-        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b
         with:
           exportToken: true
           method: jwt
@@ -239,7 +239,7 @@ jobs:
       id-token: write
     steps:
       - name: Set up Vault
-        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b
         with:
           exportToken: true
           method: jwt

--- a/.github/workflows/provision.jsonnet
+++ b/.github/workflows/provision.jsonnet
@@ -66,7 +66,7 @@ local create_pr_steps = [
 local vault_setup_steps = [
   {
     name: 'Set up Vault',
-    uses: 'hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c',  // v3.0.0
+    uses: 'hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b',  // v3.4.0
     with: {
       exportToken: true,
       method: 'jwt',

--- a/kubernetes-aks2/vault/.terraform.lock.hcl
+++ b/kubernetes-aks2/vault/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+../_common/.terraform.lock.hcl

--- a/kubernetes-aks2/vault/preprovision.py
+++ b/kubernetes-aks2/vault/preprovision.py
@@ -1,0 +1,8 @@
+from common.provisioner_utils import ProvisionerTools
+from common.variables import HASHICORP_VAULT_ADDR
+from urllib.parse import urlparse
+
+def get_vars(tools: ProvisionerTools, project: str):
+    return {
+        'vault_host': urlparse(HASHICORP_VAULT_ADDR).hostname,
+    }

--- a/kubernetes-aks2/vault/terragrunt.hcl
+++ b/kubernetes-aks2/vault/terragrunt.hcl
@@ -1,0 +1,1 @@
+../_common/terragrunt.common.hcl

--- a/kubernetes-aks2/vault/vault.tf
+++ b/kubernetes-aks2/vault/vault.tf
@@ -1,0 +1,88 @@
+variable "vault_host" {
+  type = string
+}
+
+resource "kubernetes_namespace" "vault" {
+  metadata {
+    name = "vault"
+  }
+}
+
+resource "helm_release" "vault" {
+  name       = "hashicorp-vault"
+  namespace  = kubernetes_namespace.vault.metadata[0].name
+  chart      = "vault"
+  repository = "https://helm.releases.hashicorp.com"
+  version    = "0.30.0"
+  values = [
+    yamlencode({
+      "server" : {
+        "dataStorage" : {
+          # Can't use azurefile-csi here because of permission issues during initialization.
+          "size" : "1Gi"
+        },
+        "standalone" : {
+          "enabled" : true,
+          "config" : <<-EOF
+            ui = true
+
+            listener "tcp" {
+              tls_disable = 1
+              address = "[::]:8200"
+              cluster_address = "[::]:8201"
+              # Enable unauthenticated metrics access (necessary for Prometheus Operator)
+              telemetry {
+                unauthenticated_metrics_access = "true"
+              }
+            }
+            storage "raft" {
+              path = "/vault/data"
+              node_id = "standalone-node"
+            }
+
+            # Example configuration for enabling Prometheus metrics in your config.
+            telemetry {
+              prometheus_retention_time = "30s"
+              disable_hostname = true
+            }
+            EOF
+        }
+        "ingress" : {
+          "enabled" : true,
+          "ingressClassName" : "nginx",
+          "annotations" : {
+            # Allow for larger body sizes. Used for restoring raft snapshots.
+            "nginx.ingress.kubernetes.io/proxy-body-size" : "100m",
+          },
+          "hosts" : [
+            {
+              "host" : var.vault_host,
+            }
+          ]
+        },
+        "resources" : {
+          "requests" : {
+            "cpu" : "100m",
+            "memory" : "128Mi"
+          },
+          "limits" : {
+            "cpu" : "1",
+            "memory" : "256Mi"
+          }
+        }
+      },
+      "injector" : {
+        "resources" : {
+          "requests" : {
+            "cpu" : "10m",
+            "memory" : "32Mi"
+          },
+          "limits" : {
+            "cpu" : "250m",
+            "memory" : "256Mi"
+          }
+        }
+      },
+    })
+  ]
+}

--- a/vault/main.tf
+++ b/vault/main.tf
@@ -216,6 +216,7 @@ resource "vault_jwt_auth_backend_role" "github-actions-unicorns-infra-rw" {
     "ref_type" = "branch",
     "repository" = "unicorns/infra",
   }
+  bound_audiences = ["https://github.com/unicorns"]
   token_policies = [vault_policy.provisioner-rw.name]
   role_type = "jwt"
   token_ttl = 1 * pow(60, 2) # pow(60, 2) = 1 hour (in seconds)

--- a/vault/main.tf
+++ b/vault/main.tf
@@ -194,7 +194,7 @@ resource "vault_jwt_auth_backend_role" "github-actions-unicorns-infra-ro" {
   bound_claims = {
     "repository" = "unicorns/infra",
   }
-  bound_audiences = ["github-actions"]
+  bound_audiences = ["https://github.com/unicorns"]
   token_policies = [vault_policy.provisioner-ro.name]
   role_type = "jwt"
   token_ttl = 1 * pow(60, 2) # pow(60, 2) = 1 hour (in seconds)

--- a/vault/main.tf
+++ b/vault/main.tf
@@ -194,6 +194,7 @@ resource "vault_jwt_auth_backend_role" "github-actions-unicorns-infra-ro" {
   bound_claims = {
     "repository" = "unicorns/infra",
   }
+  bound_audiences = ["github-actions"]
   token_policies = [vault_policy.provisioner-ro.name]
   role_type = "jwt"
   token_ttl = 1 * pow(60, 2) # pow(60, 2) = 1 hour (in seconds)


### PR DESCRIPTION
Deployed vault on AKS2,  backed up the AKS1 vault:

https://github.com/unicorns/infra/blob/28df5aeb1dbfc6d1f29ebf57e0ee02fb3c12f7e3/vault/vault_utils.py#L79-L92

And restored AKS2 vault from backup by following steps from the following script:

https://github.com/unicorns/infra/blob/28df5aeb1dbfc6d1f29ebf57e0ee02fb3c12f7e3/vault/start-local-vault-from-backup.sh

Also had to add a `nginx.ingress.kubernetes.io/proxy-body-size` annotation to the ingress. Otherwise the body size exceeds the limit.


Also manually updated the DNS entry in Cloudflare to point vault to AKS2 instead of AKS1.

Also had to add `bound_audiences` configuration to vault to fix the `audience claim found in JWT but no audiences bound to the role` error: https://github.com/hashicorp/vault/issues/27343

